### PR TITLE
Limit number of reported tests in extended mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Enable and configure the extension in your `codeception.yaml`
            # Limit the size of error messages in extended mode. 0 = unlimited. Default value: 80
            extendedMaxLength: 80
            
+           # Limit the amount of reported errors in extended mode. 0 = unlimited. Default value: 10
+           extendedMaxErrors: 10
+           
            # customize your message with additional prefix and/or suffix
            
            messagePrefix:     '*Smoke-Test*'

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Enable and configure the extension in your `codeception.yaml`
            # Limit the size of error messages in extended mode. 0 = unlimited. Default value: 80
            extendedMaxLength: 80
            
-           # Limit the amount of reported errors in extended mode. 0 = unlimited. Default value: 10
+           # Limit the amount of reported errors in extended mode. 0 = unlimited. Default value: 0
            extendedMaxErrors: 10
            
            # customize your message with additional prefix and/or suffix


### PR DESCRIPTION
We have an integration test suite that can trigger a big number of failures, if for example a service is down. So we've added a limit on the amount that will be reported. Thought I'd share in case you find it useful.